### PR TITLE
Add size and pixelation display options

### DIFF
--- a/lfview/resources/spatial/options.py
+++ b/lfview/resources/spatial/options.py
@@ -198,10 +198,10 @@ class OptionsPoints(_BaseElementOptions):
         OptionsSize,
         default=OptionsSize,
     )
-    style = properties.StringChoice(
-        'Points are displayed as pixels or spheres',
-        default='Pixelated',
-        choices=['Pixelated', 'Sphere'],
+    shape = properties.StringChoice(
+        'Points are displayed as squares or spheres',
+        default='Square',
+        choices=['Square', 'Sphere'],
         required=False,
     )
 

--- a/lfview/resources/spatial/options.py
+++ b/lfview/resources/spatial/options.py
@@ -198,9 +198,10 @@ class OptionsPoints(_BaseElementOptions):
         OptionsSize,
         default=OptionsSize,
     )
-    pixelated = properties.Boolean(
-        'Points are displayed as squares or glyphs',
-        default=True,
+    style = properties.StringChoice(
+        'Points are displayed as pixels or spheres',
+        default='Pixelated',
+        choices=['Pixelated', 'Sphere'],
         required=False,
     )
 

--- a/lfview/resources/spatial/options.py
+++ b/lfview/resources/spatial/options.py
@@ -200,9 +200,8 @@ class OptionsPoints(_BaseElementOptions):
     )
     shape = properties.StringChoice(
         'Points are displayed as squares or spheres',
-        default='Square',
-        choices=['Square', 'Sphere'],
-        required=False,
+        default='square',
+        choices=['square', 'sphere'],
     )
 
 

--- a/lfview/resources/spatial/options.py
+++ b/lfview/resources/spatial/options.py
@@ -193,6 +193,17 @@ class _BaseElementOptions(_BaseOptions):
 class OptionsPoints(_BaseElementOptions):
     """PointSet visualization options"""
 
+    size = properties.Instance(
+        'Default point size on the element',
+        OptionsSize,
+        default=OptionsSize,
+    )
+    pixelated = properties.Boolean(
+        'Points are displayed as squares or glyphs',
+        default=True,
+        required=False,
+    )
+
 
 class OptionsLines(_BaseElementOptions):
     """LineSet visualization options
@@ -209,7 +220,7 @@ class OptionsTubes(OptionsLines):
     and may be used with drillholes, for example.
     """
     radius = properties.Instance(
-        'Default opacity options on the element',
+        'Default radius options on the element',
         OptionsSize,
         default=OptionsSize,
     )

--- a/scripts/checkversion.sh
+++ b/scripts/checkversion.sh
@@ -68,7 +68,7 @@ elif [ $PATCH -gt $PREVIOUS_PATCH ]; then
     finish 0
 elif [ "$PATCH" -lt $PREVIOUS_PATCH ]; then
     finish 1
-elif [ $BETA -a $PREVIOUS_BETA -a $BETA -gt $ $PREVIOUS_BETA ]; then
+elif [ $BETA -a $PREVIOUS_BETA -a $BETA -gt $PREVIOUS_BETA ]; then
     finish 0
 elif [ ! $BETA -a $PREVIOUS_BETA ]; then
     finish 0

--- a/scripts/checkversion.sh
+++ b/scripts/checkversion.sh
@@ -58,19 +58,19 @@ PREVIOUS_BETA=$(echo $PREVIOUS_PATCH_BETA | awk -F'b' '{ print $2 }')
 
 if [ "$MAJOR" -gt "$PREVIOUS_MAJOR" ]; then
     finish 0
-elif [ $MAJOR -lt $PREVIOUS_MAJOR ]; then
+elif [ "$MAJOR" -lt "$PREVIOUS_MAJOR" ]; then
     finish 1
-elif [ $MINOR -gt $PREVIOUS_MINOR ]; then
+elif [ "$MINOR" -gt "$PREVIOUS_MINOR" ]; then
     finish 0
-elif [ $MINOR -lt $PREVIOUS_MINOR ]; then
+elif [ "$MINOR" -lt "$PREVIOUS_MINOR" ]; then
     finish 1
-elif [ $PATCH -gt $PREVIOUS_PATCH ]; then
+elif [ "$PATCH" -gt "$PREVIOUS_PATCH" ]; then
     finish 0
-elif [ "$PATCH" -lt $PREVIOUS_PATCH ]; then
+elif [ "$PATCH" -lt "$PREVIOUS_PATCH" ]; then
     finish 1
-elif [ $BETA -a $PREVIOUS_BETA -a $BETA -gt $PREVIOUS_BETA ]; then
+elif [ "$BETA" != "" -a "$PREVIOUS_BETA" != "" -a "$BETA" -gt "$PREVIOUS_BETA" ]; then
     finish 0
-elif [ ! $BETA -a $PREVIOUS_BETA ]; then
+elif [ "$BETA" = "" -a "$PREVIOUS_BETA" != "" ]; then
     finish 0
 fi
 

--- a/scripts/checkversion.sh
+++ b/scripts/checkversion.sh
@@ -56,19 +56,19 @@ PREVIOUS_PATCH_BETA=$(echo $PREVIOUS | awk -F'.' '{ print $3 }')
 PREVIOUS_PATCH=$(echo $PREVIOUS_PATCH_BETA | awk -F'b' '{ print $1 }')
 PREVIOUS_BETA=$(echo $PREVIOUS_PATCH_BETA | awk -F'b' '{ print $2 }')
 
-if [ "$MAJOR" -gt "$PREVIOUS_MAJOR" ]; then
+if [ $MAJOR -gt $PREVIOUS_MAJOR ]; then
     finish 0
-elif [ "$MAJOR" -lt "$PREVIOUS_MAJOR" ]; then
+elif [ $MAJOR -lt $PREVIOUS_MAJOR ]; then
     finish 1
-elif [ "$MINOR" -gt "$PREVIOUS_MINOR" ]; then
+elif [ $MINOR -gt $PREVIOUS_MINOR ]; then
     finish 0
-elif [ "$MINOR" -lt "$PREVIOUS_MINOR" ]; then
+elif [ $MINOR -lt $PREVIOUS_MINOR ]; then
     finish 1
-elif [ "$PATCH" -gt "$PREVIOUS_PATCH" ]; then
+elif [ $PATCH -gt $PREVIOUS_PATCH ]; then
     finish 0
-elif [ "$PATCH" -lt "$PREVIOUS_PATCH" ]; then
+elif [ $PATCH -lt $PREVIOUS_PATCH ]; then
     finish 1
-elif [ "$BETA" != "" -a "$PREVIOUS_BETA" != "" -a "$BETA" -gt "$PREVIOUS_BETA" ]; then
+elif [ "$BETA" != "" -a "$PREVIOUS_BETA" != "" -a $BETA -gt $PREVIOUS_BETA ]; then
     finish 0
 elif [ "$BETA" = "" -a "$PREVIOUS_BETA" != "" ]; then
     finish 0

--- a/scripts/checkversion.sh
+++ b/scripts/checkversion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # checkversion.sh
 # Copyright 2019 Seequent

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -182,14 +182,16 @@ def test_bad_volumeslices_options(prop, value):
         opt.validate()
 
 
-@pytest.mark.parametrize(('value', 'pixelated'), [
-    (0, True),
-    (100, False),
-])
-def test_good_point_options(value, pixelated):
+@pytest.mark.parametrize(
+    ('value', 'style'), [
+        (0, 'Pixelated'),
+        (100, 'Sphere'),
+    ]
+)
+def test_good_point_options(value, style):
     opt = spatial.options.OptionsPoints(
         size=spatial.options.OptionsSize(value=value),
-        pixelated=pixelated,
+        style=style,
         opacity={'value': 1},
         color={'value': 'red'}
     )
@@ -197,17 +199,17 @@ def test_good_point_options(value, pixelated):
 
 
 @pytest.mark.parametrize(
-    ('value', 'pixelated'),
+    ('value', 'style'),
     [
-        (-1, True),  # bad size value
-        (1, 'False'),  # bad pixelated value
+        (-1, 'Sphere'),  # bad size value
+        (1, 'NotAnOption'),  # bad style value
     ]
 )
-def test_bad_point_options(value, pixelated):
+def test_bad_point_options(value, style):
     with pytest.raises(properties.ValidationError):
         opt = spatial.options.OptionsPoints(
             size=spatial.options.OptionsSize(value=value),
-            pixelated=pixelated,
+            style=style,
             opacity={'value': 1},
             color={'value': 'red'}
         )
@@ -217,5 +219,5 @@ def test_bad_point_options(value, pixelated):
 def test_default_point_options():
     opt = spatial.options.OptionsPoints()
 
-    assert opt.pixelated == True
+    assert opt.style == 'Pixelated'
     assert opt.size.value == 10

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -183,15 +183,15 @@ def test_bad_volumeslices_options(prop, value):
 
 
 @pytest.mark.parametrize(
-    ('value', 'style'), [
-        (0, 'Pixelated'),
+    ('value', 'shape'), [
+        (0, 'Square'),
         (100, 'Sphere'),
     ]
 )
-def test_good_point_options(value, style):
+def test_good_point_options(value, shape):
     opt = spatial.options.OptionsPoints(
         size=spatial.options.OptionsSize(value=value),
-        style=style,
+        shape=shape,
         opacity={'value': 1},
         color={'value': 'red'}
     )
@@ -199,17 +199,17 @@ def test_good_point_options(value, style):
 
 
 @pytest.mark.parametrize(
-    ('value', 'style'),
+    ('value', 'shape'),
     [
         (-1, 'Sphere'),  # bad size value
-        (1, 'NotAnOption'),  # bad style value
+        (1, 'NotAnOption'),  # bad shape value
     ]
 )
-def test_bad_point_options(value, style):
+def test_bad_point_options(value, shape):
     with pytest.raises(properties.ValidationError):
         opt = spatial.options.OptionsPoints(
             size=spatial.options.OptionsSize(value=value),
-            style=style,
+            shape=shape,
             opacity={'value': 1},
             color={'value': 'red'}
         )
@@ -219,5 +219,5 @@ def test_bad_point_options(value, style):
 def test_default_point_options():
     opt = spatial.options.OptionsPoints()
 
-    assert opt.style == 'Pixelated'
+    assert opt.shape == 'Square'
     assert opt.size.value == 10

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -184,8 +184,8 @@ def test_bad_volumeslices_options(prop, value):
 
 @pytest.mark.parametrize(
     ('value', 'shape'), [
-        (0, 'Square'),
-        (100, 'Sphere'),
+        (0, 'square'),
+        (100, 'sphere'),
     ]
 )
 def test_good_point_options(value, shape):
@@ -201,7 +201,7 @@ def test_good_point_options(value, shape):
 @pytest.mark.parametrize(
     ('value', 'shape'),
     [
-        (-1, 'Sphere'),  # bad size value
+        (-1, 'sphere'),  # bad size value
         (1, 'NotAnOption'),  # bad shape value
     ]
 )
@@ -219,5 +219,5 @@ def test_bad_point_options(value, shape):
 def test_default_point_options():
     opt = spatial.options.OptionsPoints()
 
-    assert opt.shape == 'Square'
+    assert opt.shape == 'square'
     assert opt.size.value == 10

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -126,6 +126,7 @@ expected_type = {
     'opacity': spatial.options.OptionsOpacity,
     'color': spatial.options.OptionsColor,
     'radius': spatial.options.OptionsSize,
+    'size': spatial.options.OptionsSize,
     'wireframe': spatial.options.OptionsWireframe,
     'textures': list,
 }
@@ -133,7 +134,7 @@ expected_type = {
 
 @pytest.mark.parametrize(
     ('options_class', 'expected_props'), [
-        (spatial.OptionsPoints, ['opacity', 'color']),
+        (spatial.OptionsPoints, ['opacity', 'color', 'size']),
         (spatial.OptionsLines, ['opacity', 'color']),
         (spatial.OptionsTubes, ['opacity', 'color', 'radius']),
         (
@@ -179,3 +180,42 @@ def test_bad_volumeslices_options(prop, value):
     with pytest.raises(properties.ValidationError):
         setattr(opt, prop, value)
         opt.validate()
+
+
+@pytest.mark.parametrize(('value', 'pixelated'), [
+    (0, True),
+    (100, False),
+])
+def test_good_point_options(value, pixelated):
+    opt = spatial.options.OptionsPoints(
+        size=spatial.options.OptionsSize(value=value),
+        pixelated=pixelated,
+        opacity={'value': 1},
+        color={'value': 'red'}
+    )
+    assert opt.validate()
+
+
+@pytest.mark.parametrize(
+    ('value', 'pixelated'),
+    [
+        (-1, True),  # bad size value
+        (1, 'False'),  # bad pixelated value
+    ]
+)
+def test_bad_point_options(value, pixelated):
+    with pytest.raises(properties.ValidationError):
+        opt = spatial.options.OptionsPoints(
+            size=spatial.options.OptionsSize(value=value),
+            pixelated=pixelated,
+            opacity={'value': 1},
+            color={'value': 'red'}
+        )
+        opt.validate()
+
+
+def test_default_point_options():
+    opt = spatial.options.OptionsPoints()
+
+    assert opt.pixelated == True
+    assert opt.size.value == 10


### PR DESCRIPTION
best way atm to test with the api is to update `requirements.txt` in `cp-api` like so:
```diff
diff --git a/requirements.txt b/requirements.txt
+-e ./deps/lfview-resources-spatial
 -e ./deps/afterburner
 -e ./deps/metronome
 -e ./deps/audition
```
clone `lfview-resources-spatial` to `deps` folder in the api and run `make build`